### PR TITLE
Search for rules in /usr/lib/udev/rules.d

### DIFF
--- a/ProgramExe/FlashTool
+++ b/ProgramExe/FlashTool
@@ -4,13 +4,17 @@ rootandudevcheck() {
     if [ "$(whoami)" != "root" ]
     then
         export HASRULES="false"
-        if test -d /etc/udev/rules.d
-        then
-            if grep -rl "0fce" /etc/udev/rules.d >/dev/null
+        local _RULES_DIR="/etc/udev/rules.d /usr/lib/udev/rules.d"
+        for dir in $_RULES_DIR; do
+            if test -d $dir
             then
-                export HASRULES="true"
+                if grep -rl "0fce" $dir >/dev/null
+                then
+                    export HASRULES="true"
+                    break
+                fi
             fi
-        fi
+        done
         if test "$HASRULES" = "true"
         then
     		echo "Not running as root but Sony/SonyEriccson Vendor ID found on your udev rules"

--- a/ProgramExe/FlashToolConsole
+++ b/ProgramExe/FlashToolConsole
@@ -10,13 +10,17 @@ rootandudevcheck() {
     if [ "$(whoami)" != "root" ]
     then
         export HASRULES="false"
-        if test -d /etc/udev/rules.d
-        then
-            if grep -rl "0fce" /etc/udev/rules.d >/dev/null
+        local _RULES_DIR="/etc/udev/rules.d /usr/lib/udev/rules.d"
+        for dir in $_RULES_DIR; do
+            if test -d $dir
             then
-                export HASRULES="true"
+                if grep -rl "0fce" $dir >/dev/null
+                then
+                    export HASRULES="true"
+                    break
+                fi
             fi
-        fi
+        done
         if test "$HASRULES" = "true"
         then
                 echo "Not running as root but Sony/SonyEriccson Vendor ID found on your udev rules"


### PR DESCRIPTION
Some distros (e.g. Arch Linux) provide packages to install rules to system-wide location, so we should search the directory for rules, too.
