### PR TITLE
Use JAVA_HOME if available

### DIFF
--- a/ProgramExe/FlashTool
+++ b/ProgramExe/FlashTool
@@ -38,11 +38,14 @@ then
 
     rootandudevcheck;
 
-    if test "${system64}" = "x86_64"
+    if test -z "${JAVA_HOME}"
     then
-        export JAVA_HOME=./x10flasher_lib/linjre64
-    else
-        export JAVA_HOME=./x10flasher_lib/linjre32
+        if test "${system64}" = "x86_64"
+        then
+            export JAVA_HOME=./x10flasher_lib/linjre64
+        else
+            export JAVA_HOME=./x10flasher_lib/linjre32
+        fi
     fi
 
     echo "Used java home : ${JAVA_HOME}"
@@ -77,11 +80,14 @@ then
 
 else
 
-    if test "${system64}" = "x86_64"
+    if test -z "${JAVA_HOME}"
     then
-        export JAVA_HOME=./x10flasher_lib/macjre64       
-    else
-        export JAVA_HOME=./x10flasher_lib/macjre32
+        if test "${system64}" = "x86_64"
+        then
+            export JAVA_HOME=./x10flasher_lib/macjre64       
+        else
+            export JAVA_HOME=./x10flasher_lib/macjre32
+        fi
     fi
 
     echo "Used java home : ${JAVA_HOME}"


### PR DESCRIPTION
This restores the old behavior of using system JAVA_HOME if available. It would be nice to have this for me, but if this behavior was removed intentionally then I apologize.